### PR TITLE
Wikipedia: link to the specific sections and use revision IDs

### DIFF
--- a/app/views/scotland_regd_la_mappings/_scottish_mappings_header.html.erb
+++ b/app/views/scotland_regd_la_mappings/_scottish_mappings_header.html.erb
@@ -26,7 +26,7 @@ Based on data from www.nrscotland.gov.uk
   <div class="panel-body">
     <p>
 "Registration districts in Scotland came into being with the introduction of civil registration there in 1855; away from the cities their boundaries usually coincided with civil parishes. They still exist today in their own right and <strong>in many places do not coincide with the current council areas</strong>; commonly both geographically large and densely populated Council Areas will have several registration districts, each with a registrar within easy reach of most residents."
-<a href="https://en.wikipedia.org/wiki/Registration_district">Source on Wikipedia</a>
+<a href="https://en.wikipedia.org/wiki/Registration_district?oldid=588554443#Scotland">Source on Wikipedia</a>
 </p>
 
 <p>

--- a/app/views/ward_regd_la_mappings/_mappings_header.html.erb
+++ b/app/views/ward_regd_la_mappings/_mappings_header.html.erb
@@ -29,7 +29,7 @@ Based on data from ONS
 "Registration districts <strong>are not always co-terminous with county boundaries</strong>, and so in the past were grouped into "registration counties" for statistical purposes.""
 </p>
 <p>
-<a href="https://en.wikipedia.org/wiki/Registration_district">Source on Wikipedia</a>
+<a href="https://en.wikipedia.org/wiki/Registration_district?oldid=588554443#England_and_Wales">Source on Wikipedia</a>
 </p>
     </p>
   </div>
@@ -73,5 +73,3 @@ Based on data from ONS
     </div>
     </div>
     </nav>
-
-


### PR DESCRIPTION
- In case the page changes at some point to remove the text that we
  cite, link to a specific revision (588554443) so we always have
  evidence.

(Once a Wikimedian, always a Wikimedian - sorry!)
